### PR TITLE
fix broken multiconfiguration handling

### DIFF
--- a/inc/header.php
+++ b/inc/header.php
@@ -1,11 +1,11 @@
 <?php
+session_name('MySQLDumper');
+session_start();
 include(dirname(__FILE__) . '/functions.php');
 $msd_path = basePath();
 if (!defined('MSD_PATH')) {
     define('MSD_PATH', $msd_path);
 }
-session_name('MySQLDumper');
-session_start();
 if (!isset($download)) {
     header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
     header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT");


### PR DESCRIPTION
can't load right configuration, because session is loaded to late
occurs errors in
- config_overview -> save all changes to mysqldump conf only
- all db connection outside the mysqldump conf