### PR TITLE
fix access denied error

### DIFF
--- a/inc/mysql.php
+++ b/inc/mysql.php
@@ -252,9 +252,9 @@ function MSD_mysql_connect($encoding='utf8', $keycheck_off=false, $actual_table=
     if (isset($config['dbconnection']) && is_resource($config['dbconnection'])) {
         return $config['dbconnection'];
     }
-	$port=( isset($config['dbport']) && !empty($config['dbport']) ) ? ':' . $config['dbport'] : '';
-	$socket=( isset($config['dbsocket']) && !empty($config['dbsocket']) ) ? ':' . $config['dbsocket'] : '';
-	$config['dbconnection']=@($GLOBALS["___mysqli_ston"] = mysqli_connect($config['dbhost'] . $port . $socket, $config['dbuser'], $config['dbpass'])) or die(SQLError("Error establishing a database connection!", ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))));
+	$port=( isset($config['dbport']) && !empty($config['dbport']) ) ? $config['dbport'] : '';
+	$socket=( isset($config['dbsocket']) && !empty($config['dbsocket']) ) ? $config['dbsocket'] : '';
+	$config['dbconnection']=($GLOBALS["___mysqli_ston"] = mysqli_connect($config['dbhost'], $config['dbuser'], $config['dbpass'], "", $port, $socket))  or die(SQLError("Error establishing a database connection!", ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))));
 	if (!defined('MSD_MYSQL_VERSION')) GetMySQLVersion();
 
 	if (!isset($config['mysql_standard_character_set']) || $config['mysql_standard_character_set'] == '') get_sql_encodings();


### PR DESCRIPTION
in contrast to mysql_connect, it is not allowed to attach the port or the socket to the host name for the mysqli_connect command. There are separate parameters for that now. This leads to "Access denied for user 'user123'@'localhost' (using password: NO) " errors in the current version if port or socket is specified