### PR TITLE
Fixed some issues with PHP >= 7.2 count() behavior

### DIFF
--- a/inc/functions_sql.php
+++ b/inc/functions_sql.php
@@ -18,7 +18,7 @@ function ReadSQL()
 		fclose($fp);
 		@chmod($sf,0777);
 	}
-	if (count($SQL_ARRAY) == 0 && filesize($sf) > 0)
+	if ((!is_array($SQL_ARRAY) || count($SQL_ARRAY) == 0) && filesize($sf) > 0)
 	{
 		$SQL_ARRAY=file($sf);
 	}
@@ -63,7 +63,7 @@ function SQL_ComboBox()
 {
 	global $SQL_ARRAY,$tablename,$nl;
 	$s='';
-	if (count($SQL_ARRAY) > 0)
+	if (is_array($SQL_ARRAY) && count($SQL_ARRAY) > 0)
 	{
 		$s=$nl . $nl . '<select class="SQLCombo" name="sqlcombo" onchange="this.form.sqltextarea.value=this.options[this.selectedIndex].value;">' . $nl;
 		$s.='<option value="" selected>---</option>' . $nl;
@@ -533,7 +533,7 @@ function correct_post_index($index)
 function ComboCommandDump($when, $index, $disabled = '')
 {
 	global $SQL_ARRAY,$nl,$databases,$lang;
-	if (count($SQL_ARRAY) == 0)
+	if (!is_array($SQL_ARRAY) || count($SQL_ARRAY) == 0)
 	{
 		$r='<a href="sql.php?context=1" class="uls">' . $lang['L_SQL_BEFEHLE'] . '</a>';
 		if ($when == 0) $r.='<input type="hidden" name="command_before_' . $index . '" value="">';

--- a/inc/sqlbrowser/sql_commands.php
+++ b/inc/sqlbrowser/sql_commands.php
@@ -7,12 +7,12 @@ function nl2null($string)
 	return trim(str_replace($search,$replace,$string));	
 }
 //SQL-Strings
-echo $aus.='<h4>' . $lang['L_SQL_BEFEHLE'] . ' (' . count($SQL_ARRAY) . ')</h4>';
+echo $aus.='<h4>' . $lang['L_SQL_BEFEHLE'] . ' (' . (is_array($SQL_ARRAY)? count($SQL_ARRAY) : 0) . ')</h4>';
 echo '<a href="' . $params . '&amp;sqlconfig=1&amp;new=1">' . $lang['L_SQL_BEFEHLNEU'] . '</a><br><br>';
 if (isset($_POST['sqlnewupdate']))
 {
-	$ind=count($SQL_ARRAY);
-	if (count($SQL_ARRAY) > 0) array_push($SQL_ARRAY,$_POST['sqlname' . $ind] . "|" . $_POST['sqlstring' . $ind]);
+	$ind=(is_array($SQL_ARRAY))? count($SQL_ARRAY) : 0;
+	if ($ind > 0) array_push($SQL_ARRAY,$_POST['sqlname' . $ind] . "|" . $_POST['sqlstring' . $ind]);
 	else $SQL_ARRAY[0]=htmlspecialchars($_POST['sqlname0'],ENT_COMPAT ,'UTF-8') . '|' . $_POST['sqlstring0'];
 	WriteSQL();
 	echo '<p>' . $lang['L_SQL_BEFEHLSAVED1'] . ' \'' . $_POST['sqlname' . $ind] . '\' ' . $lang['L_SQL_BEFEHLSAVED2'] . '</p>';
@@ -24,7 +24,7 @@ echo '<form name="sqlform" action="sql.php" method="post">
 	<input type="hidden" name="dbid" value="' . $dbid . '">';
 echo '<table class="bdr" style="width:100%"><tr class="thead"><th>#</th><th>' . $lang['L_NAME'] . '</th><th>SQL</th><th>' . $lang['L_COMMAND'] . '</th></tr>';
 $i=0;
-if (count($SQL_ARRAY) > 0)
+if (is_array($SQL_ARRAY) && count($SQL_ARRAY) > 0)
 {
 	for ($i=0; $i < count($SQL_ARRAY); $i++)
 	{

--- a/restore.php
+++ b/restore.php
@@ -120,7 +120,7 @@ if ($restore['filehandle'])
 		{
 			@mysqli_query($config['dbconnection'], '/*!40000 ALTER TABLE `'.$restore['actual_table'].'` DISABLE KEYS */;');
 		}
-		elseif (sizeof($restore['tables_to_restore'])==0&&($restore['actual_table']>''&&$restore['actual_table']!='unbekannt')) @mysqli_query($config['dbconnection'], '/*!40000 ALTER TABLE `'.$restore['actual_table'].'` DISABLE KEYS */;');
+		elseif ((!is_array($restore['tables_to_restore'])||sizeof($restore['tables_to_restore'])==0)&&($restore['actual_table']>''&&$restore['actual_table']!='unbekannt')) @mysqli_query($config['dbconnection'], '/*!40000 ALTER TABLE `'.$restore['actual_table'].'` DISABLE KEYS */;');
 		
 		WHILE (($a<$restore['anzahl_zeilen'])&&(!$restore['fileEOF'])&&($dauer<$restore['max_zeit'])&&!$restore['EOB'])
 		{


### PR DESCRIPTION
Hello there!

I recently found some PHP Warnings when using MySQLDumper in a PHP 7.2.x environment due to the changed behaviour of count() and sizeof(). The warnings occured on the MySQLDumper page "_Configuration_", in "_Configuration_" -> "_Databases_" -> "_SQL Commands_" and during a DB-Restore.

I fixed the problems and thought I could share them with you. I did some test backups & restores and played around with the configuration panel a bit and it seems it works fine.

However, this is my first time diving deeper into the MySQLDumper code, so please have a closer look at my changes if you consider to accept this pull request. The changes affect some global vars and maybe I have overseen a scenario where these vars are used differently somewhere else.

Sincerely,
Chris